### PR TITLE
split reverse projections

### DIFF
--- a/braun.js
+++ b/braun.js
@@ -3,7 +3,7 @@
 const h = require('./helpers')
 
 const braun = (point, opt) => {
-	point = h.check(point)
+	point = h.validatePoint(point)
 	opt = h.options(opt)
 	if(point.wgs){
 		point = h.addMeridian(point, opt.meridian)

--- a/braun.js
+++ b/braun.js
@@ -2,23 +2,29 @@
 
 const h = require('./helpers')
 
-const braun = (point, opt) => {
-	point = h.validatePoint(point)
+const braunProject = (point, opt) => {
+	h.assertValidUnprojected(point)
 	opt = h.options(opt)
-	if(point.wgs){
-		point = h.addMeridian(point, opt.meridian)
-		return {
-			x: h.rad(point.lon)/(2*Math.PI)+0.5,
-			y: (h.tan(opt.latLimit/2)-h.tan(point.lat/2))/(Math.PI)
-		}
-	}
-	else{
-		const result = {
-			lon: h.deg((2*point.x-1)*Math.PI),
-			lat: h.deg(2*Math.atan(h.tan(opt.latLimit/2)-point.y*Math.PI))
-		}
-		return h.addMeridian(result, opt.meridian*(-1))
+
+	point = h.addMeridian(point, opt.meridian)
+	return {
+		x: h.rad(point.lon) / (2 * Math.PI) + 0.5,
+		y: (h.tan(opt.latLimit / 2) - h.tan(point.lat / 2)) / Math.PI
 	}
 }
 
-module.exports = braun
+const braunInverse = (point, opt) => {
+	h.assertValidProjected(point)
+	opt = h.options(opt)
+
+	const result = {
+		lon: h.deg((2 * point.x - 1) * Math.PI),
+		lat: h.deg(2 * Math.atan(h.tan(opt.latLimit / 2) - point.y * Math.PI))
+	}
+	return h.addMeridian(result, opt.meridian * -1)
+}
+
+module.exports = {
+	project: braunProject,
+	inverse: braunInverse
+}

--- a/central-cylindrical.js
+++ b/central-cylindrical.js
@@ -3,7 +3,7 @@
 const h = require('./helpers')
 
 const centralCylindrical = (point, opt) => {
-	point = h.check(point)
+	point = h.validatePoint(point)
 	opt = h.options(opt)
 	if(point.wgs){
 		point = h.addMeridian(point, opt.meridian)

--- a/central-cylindrical.js
+++ b/central-cylindrical.js
@@ -2,23 +2,29 @@
 
 const h = require('./helpers')
 
-const centralCylindrical = (point, opt) => {
-	point = h.validatePoint(point)
+const centralCylindricalProject = (point, opt) => {
+	h.assertValidUnprojected(point)
 	opt = h.options(opt)
-	if(point.wgs){
-		point = h.addMeridian(point, opt.meridian)
-		return {
-			x: h.rad(point.lon)/(2*Math.PI)+0.5,
-			y: (h.tan(opt.latLimit)-h.tan(point.lat))/(2*Math.PI)
-		}
-	}
-	else{
-		const result = {
-			lon: h.deg((2*point.x-1)*Math.PI),
-			lat: h.deg(Math.atan(h.tan(opt.latLimit)-2*Math.PI*point.y))
-		}
-		return h.addMeridian(result, opt.meridian*(-1))
+
+	point = h.addMeridian(point, opt.meridian)
+	return {
+		x: h.rad(point.lon) / (2 * Math.PI) + 0.5,
+		y: (h.tan(opt.latLimit) - h.tan(point.lat)) / (2 * Math.PI)
 	}
 }
 
-module.exports = centralCylindrical
+const centralCylindricalInverse = (point, opt) => {
+	h.assertValidProjected(point)
+	opt = h.options(opt)
+
+	const result = {
+		lon: h.deg((2 * point.x - 1) * Math.PI),
+		lat: h.deg(Math.atan(h.tan(opt.latLimit) - 2 * Math.PI * point.y))
+	}
+	return h.addMeridian(result, opt.meridian * -1)
+}
+
+module.exports = {
+	project: centralCylindricalProject,
+	inverse: centralCylindricalInverse
+}

--- a/equirectangular.js
+++ b/equirectangular.js
@@ -2,23 +2,29 @@
 
 const h = require('./helpers')
 
-const equirectangular = (point, opt) => {
-	point = h.validatePoint(point)
+const equirectangularProject = (point, opt) => {
+	h.assertValidUnprojected(point)
 	opt = h.options(opt)
-	if(point.wgs){
-		point = h.addMeridian(point, opt.meridian)
-		return {
-			x: h.rad(point.lon)*h.cos(opt.standardParallel)/(2*Math.PI)+0.5,
-			y: 0.25-(h.rad(point.lat)-h.rad(opt.standardParallel))/(2*Math.PI)
-		}
-	}
-	else{
-		const result = {
-			lon: h.deg((2*point.x-1)*Math.PI*h.cos(opt.standardParallel)),
-			lat: h.deg((0.25-point.y)*2*Math.PI+h.rad(opt.standardParallel))
-		}
-		return h.addMeridian(result, opt.meridian*(-1))
+
+	point = h.addMeridian(point, opt.meridian)
+	return {
+		x: h.rad(point.lon) * h.cos(opt.standardParallel) / (2 * Math.PI) + 0.5,
+		y: 0.25 - (h.rad(point.lat) - h.rad(opt.standardParallel)) / (2 * Math.PI)
 	}
 }
 
-module.exports = equirectangular
+const equirectangularInverse = (point, opt) => {
+	h.assertValidProjected(point)
+	opt = h.options(opt)
+
+	const result = {
+		lon: h.deg((2 * point.x - 1) * Math.PI * h.cos(opt.standardParallel)),
+		lat: h.deg((0.25 - point.y) * 2 * Math.PI + h.rad(opt.standardParallel))
+	}
+	return h.addMeridian(result, opt.meridian * -1)
+}
+
+module.exports = {
+	project: equirectangularProject,
+	inverse: equirectangularInverse
+}

--- a/equirectangular.js
+++ b/equirectangular.js
@@ -3,7 +3,7 @@
 const h = require('./helpers')
 
 const equirectangular = (point, opt) => {
-	point = h.check(point)
+	point = h.validatePoint(point)
 	opt = h.options(opt)
 	if(point.wgs){
 		point = h.addMeridian(point, opt.meridian)

--- a/gall-peters.js
+++ b/gall-peters.js
@@ -2,23 +2,29 @@
 
 const h = require('./helpers')
 
-const gallPeters = (point, opt) => {
-	point = h.validatePoint(point)
+const gallPetersProject = (point, opt) => {
+	h.assertValidUnprojected(point)
 	opt = h.options(opt)
-	if(point.wgs){
-		point = h.addMeridian(point, opt.meridian)
-		return {
-			x: h.rad(point.lon)/(2*Math.PI)+0.5,
-			y: (1-h.sin(point.lat))/Math.PI
-		}
-	}
-	else{
-		const result = {
-			lon: h.deg((2*point.x-1)*Math.PI),
-			lat: h.deg(Math.asin(1-point.y*Math.PI))
-		}
-		return h.addMeridian(result, opt.meridian*(-1))
+
+	point = h.addMeridian(point, opt.meridian)
+	return {
+		x: h.rad(point.lon) / (2 * Math.PI) + 0.5,
+		y: (1 - h.sin(point.lat)) / Math.PI
 	}
 }
 
-module.exports = gallPeters
+const gallPetersInverse = (point, opt) => {
+	h.assertValidProjected(point)
+	opt = h.options(opt)
+
+	const result = {
+		lon: h.deg((2 * point.x - 1) * Math.PI),
+		lat: h.deg(Math.asin(1 - point.y * Math.PI))
+	}
+	return h.addMeridian(result, opt.meridian * -1)
+}
+
+module.exports = {
+	project: gallPetersProject,
+	inverse: gallPetersInverse
+}

--- a/gall-peters.js
+++ b/gall-peters.js
@@ -3,7 +3,7 @@
 const h = require('./helpers')
 
 const gallPeters = (point, opt) => {
-	point = h.check(point)
+	point = h.validatePoint(point)
 	opt = h.options(opt)
 	if(point.wgs){
 		point = h.addMeridian(point, opt.meridian)

--- a/gall.js
+++ b/gall.js
@@ -3,7 +3,7 @@
 const h = require('./helpers')
 
 const gall = (point, opt) => {
-	point = h.check(point)
+	point = h.validatePoint(point)
 	opt = h.options(opt)
 	if(point.wgs){
 		point = h.addMeridian(point, opt.meridian)

--- a/gall.js
+++ b/gall.js
@@ -2,23 +2,29 @@
 
 const h = require('./helpers')
 
-const gall = (point, opt) => {
-	point = h.validatePoint(point)
+const gallProject = (point, opt) => {
+	h.assertValidUnprojected(point)
 	opt = h.options(opt)
-	if(point.wgs){
-		point = h.addMeridian(point, opt.meridian)
-		return {
-			x: h.rad(point.lon)/(2*Math.PI)+0.5,
-			y: (h.tan(opt.latLimit/2)-h.tan(point.lat/2))/(2*Math.PI)*(1+Math.sqrt(2))
-		}
-	}
-	else{
-		const result = {
-			lon: h.deg((2*point.x-1)*Math.PI),
-			lat: h.deg(2*Math.atan(h.tan(opt.latLimit/2)-2*Math.PI*point.y/(1+Math.sqrt(2))))
-		}
-		return h.addMeridian(result, opt.meridian*(-1))
+
+	point = h.addMeridian(point, opt.meridian)
+	return {
+		x: h.rad(point.lon) / (2 * Math.PI) + 0.5,
+		y: (h.tan(opt.latLimit / 2) - h.tan(point.lat / 2)) / (2 * Math.PI) * (1 + Math.sqrt(2))
 	}
 }
 
-module.exports = gall
+const gallInverse = (point, opt) => {
+	h.assertValidProjected(point)
+	opt = h.options(opt)
+
+	const result = {
+		lon: h.deg((2 * point.x - 1) * Math.PI),
+		lat: h.deg(2 * Math.atan(h.tan(opt.latLimit / 2) - 2 * Math.PI * point.y / (1 + Math.sqrt(2))))
+	}
+	return h.addMeridian(result, opt.meridian * -1)
+}
+
+module.exports = {
+	project: gallProject,
+	inverse: gallInverse
+}

--- a/helpers.js
+++ b/helpers.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const rad = (deg) => deg*Math.PI/180
+const rad = (deg) => deg * Math.PI / 180
 const sin = (deg) => Math.sin(rad(deg))
 const cos = (deg) => Math.cos(rad(deg))
 const tan = (deg) => Math.tan(rad(deg))
-const deg = (rad) => rad*180/Math.PI
+const deg = (rad) => rad * 180 / Math.PI
 
 const defaults = {
 	meridian: 0,
@@ -13,8 +13,15 @@ const defaults = {
 }
 
 const check = (point) => {
-	if(point.x!==undefined&&point.x>=0&&point.x<=1&&point.y!==undefined&&point.lon===undefined&&point.lat===undefined) return {x: +point.x, y: +point.y, wgs: false}
-	if(point.lon!==undefined&&point.lat!==undefined&&point.x===undefined&&point.y===undefined) return {lon: +point.lon, lat: +point.lat, wgs: true}
+	if (point.x !== undefined && point.x >= 0 && point.x <= 1 &&
+		point.y !== undefined &&
+		point.lon === undefined && point.lat === undefined) {
+		return {x: +point.x, y: +point.y, wgs: false}
+	}
+	if (point.lon !== undefined && point.lat !== undefined &&
+		point.x === undefined && point.y === undefined) {
+		return {lon: +point.lon, lat: +point.lat, wgs: true}
+	}
 	throw new Error('Invalid input point.')
 }
 
@@ -24,8 +31,16 @@ const options = (opt) => {
 
 const addMeridian = (point, meridian) => {
 	point = check(point)
-	if(meridian!==0) return check({lon: ((point.lon+180+360-meridian)%360)-180, lat: point.lat})
+	if (meridian !== 0) return check({
+		lon: ((point.lon + 180 + 360 - meridian) % 360) - 180,
+		lat: point.lat
+	})
 	return point
 }
 
-module.exports = {rad, sin, cos, tan, deg, addMeridian, check, options}
+module.exports = {
+	rad, sin, cos, tan, deg,
+	options,
+	check,
+	addMeridian
+}

--- a/helpers.js
+++ b/helpers.js
@@ -12,22 +12,20 @@ const defaults = {
 	latLimit: 85
 }
 
-const validatePoint = (point) => {
+const assertValidUnprojected = (point) => {
+	if (('lon' in point) && ('lat' in point)) {
+		if ('number' !== typeof point.lon) throw new Error('point.lon must be a number')
+		if ('number' !== typeof point.lat) throw new Error('point.lat must be a number')
+	} else throw new Error('point must an object with `lon` and `lat`')
+}
+
+const assertValidProjected = (point) => {
 	if (('x' in point) && ('y' in point)) {
 		if ('number' !== typeof point.x) throw new Error('point.x must be a number')
 		if ('number' !== typeof point.y) throw new Error('point.y must be a number')
 		if (point.x < 0) throw new Error('point.x must be >= 0')
 		if (point.x > 1) throw new Error('point.x must be <= 1')
-		return {x: point.x, y: point.y, wgs: false}
-	}
-
-	if (('lon' in point) && ('lat' in point)) {
-		if ('number' !== typeof point.lon) throw new Error('point.lon must be a number')
-		if ('number' !== typeof point.lat) throw new Error('point.lat must be a number')
-		return {lon: point.lon, lat: point.lat, wgs: true}
-	}
-
-	throw new Error('point must either have x & y or lon & lat')
+	} else throw new Error('point must be an object with `x` and `y`')
 }
 
 const options = (opt) => {
@@ -35,17 +33,18 @@ const options = (opt) => {
 }
 
 const addMeridian = (point, meridian) => {
-	point = validatePoint(point)
-	if (meridian !== 0) return validatePoint({
+	assertValidUnprojected(point)
+	if (meridian === 0) return point
+	else return {
 		lon: ((point.lon + 180 + 360 - meridian) % 360) - 180,
 		lat: point.lat
-	})
-	return point
+	}
 }
 
 module.exports = {
 	rad, sin, cos, tan, deg,
+	assertValidUnprojected,
+	assertValidProjected,
 	options,
-	validatePoint,
 	addMeridian
 }

--- a/helpers.js
+++ b/helpers.js
@@ -12,17 +12,22 @@ const defaults = {
 	latLimit: 85
 }
 
-const check = (point) => {
-	if (point.x !== undefined && point.x >= 0 && point.x <= 1 &&
-		point.y !== undefined &&
-		point.lon === undefined && point.lat === undefined) {
-		return {x: +point.x, y: +point.y, wgs: false}
+const validatePoint = (point) => {
+	if (('x' in point) && ('y' in point)) {
+		if ('number' !== typeof point.x) throw new Error('point.x must be a number')
+		if ('number' !== typeof point.y) throw new Error('point.y must be a number')
+		if (point.x < 0) throw new Error('point.x must be >= 0')
+		if (point.x > 1) throw new Error('point.x must be <= 1')
+		return {x: point.x, y: point.y, wgs: false}
 	}
-	if (point.lon !== undefined && point.lat !== undefined &&
-		point.x === undefined && point.y === undefined) {
-		return {lon: +point.lon, lat: +point.lat, wgs: true}
+
+	if (('lon' in point) && ('lat' in point)) {
+		if ('number' !== typeof point.lon) throw new Error('point.lon must be a number')
+		if ('number' !== typeof point.lat) throw new Error('point.lat must be a number')
+		return {lon: point.lon, lat: point.lat, wgs: true}
 	}
-	throw new Error('Invalid input point.')
+
+	throw new Error('point must either have x & y or lon & lat')
 }
 
 const options = (opt) => {
@@ -30,8 +35,8 @@ const options = (opt) => {
 }
 
 const addMeridian = (point, meridian) => {
-	point = check(point)
-	if (meridian !== 0) return check({
+	point = validatePoint(point)
+	if (meridian !== 0) return validatePoint({
 		lon: ((point.lon + 180 + 360 - meridian) % 360) - 180,
 		lat: point.lat
 	})
@@ -41,6 +46,6 @@ const addMeridian = (point, meridian) => {
 module.exports = {
 	rad, sin, cos, tan, deg,
 	options,
-	check,
+	validatePoint,
 	addMeridian
 }

--- a/kavrayskiy-7.js
+++ b/kavrayskiy-7.js
@@ -3,7 +3,7 @@
 const h = require('./helpers')
 
 const kavrayskiy7 = (point, opt) => {
-	point = h.check(point)
+	point = h.validatePoint(point)
 	opt = h.options(opt)
 	if(point.wgs){
 		point = h.addMeridian(point, opt.meridian)

--- a/kavrayskiy-7.js
+++ b/kavrayskiy-7.js
@@ -2,24 +2,30 @@
 
 const h = require('./helpers')
 
-const kavrayskiy7 = (point, opt) => {
-	point = h.validatePoint(point)
+const kavrayskiy7Project = (point, opt) => {
+	h.assertValidUnprojected(point)
 	opt = h.options(opt)
-	if(point.wgs){
-		point = h.addMeridian(point, opt.meridian)
-		return {
-			x: h.rad(point.lon)*Math.sqrt(1/3-Math.pow(h.rad(point.lat)/Math.PI, 2)) * Math.sqrt(3)/(2*Math.PI)+0.5,
-			y: (Math.PI/2-h.rad(point.lat)) / (Math.sqrt(3)*Math.PI)
-		}
-	}
-	else{
-		const lat = Math.PI/2 - point.y*Math.sqrt(3)*Math.PI
-		const result = {
-			lon: h.deg((2*point.x-1)*Math.PI/(Math.sqrt(1/3-Math.pow(lat/Math.PI, 2))*Math.sqrt(3))),
-			lat: h.deg(lat)
-		}
-		return h.addMeridian(result, opt.meridian*(-1))
+
+	point = h.addMeridian(point, opt.meridian)
+	return {
+		x: h.rad(point.lon) * Math.sqrt(1/3 - Math.pow(h.rad(point.lat) / Math.PI, 2)) * Math.sqrt(3) / (2 * Math.PI) + 0.5,
+		y: (Math.PI / 2 - h.rad(point.lat)) / (Math.sqrt(3) * Math.PI)
 	}
 }
 
-module.exports = kavrayskiy7
+const kavrayskiy7Inverse = (point, opt) => {
+	h.assertValidProjected(point)
+	opt = h.options(opt)
+
+	const lat = Math.PI / 2 - point.y * Math.sqrt(3) * Math.PI
+	const result = {
+		lon: h.deg((2 * point.x - 1) * Math.PI / (Math.sqrt(1/3 - Math.pow(lat / Math.PI, 2)) * Math.sqrt(3))),
+		lat: h.deg(lat)
+	}
+	return h.addMeridian(result, opt.meridian * -1)
+}
+
+module.exports = {
+	project: kavrayskiy7Project,
+	inverse: kavrayskiy7Inverse
+}

--- a/lambert.js
+++ b/lambert.js
@@ -3,7 +3,7 @@
 const h = require('./helpers')
 
 const lambert = (point, opt) => {
-	point = h.check(point)
+	point = h.validatePoint(point)
 	opt = h.options(opt)
 	if(point.wgs){
 		point = h.addMeridian(point, opt.meridian)

--- a/lambert.js
+++ b/lambert.js
@@ -2,23 +2,29 @@
 
 const h = require('./helpers')
 
-const lambert = (point, opt) => {
-	point = h.validatePoint(point)
+const lambertProject = (point, opt) => {
+	h.assertValidUnprojected(point)
 	opt = h.options(opt)
-	if(point.wgs){
-		point = h.addMeridian(point, opt.meridian)
-		return {
-			x: h.rad(point.lon)/(2*Math.PI)+0.5,
-			y: (1-h.sin(point.lat))/(2*Math.PI)
-		}
-	}
-	else{
-		const result = {
-			lon: h.deg((2*point.x-1)*Math.PI),
-			lat: h.deg(Math.asin(1-2*Math.PI*point.y))
-		}
-		return h.addMeridian(result, opt.meridian*(-1))
+
+	point = h.addMeridian(point, opt.meridian)
+	return {
+		x: h.rad(point.lon) / (2 * Math.PI) + 0.5,
+		y: (1 - h.sin(point.lat)) / (2 * Math.PI)
 	}
 }
 
-module.exports = lambert
+const lambertInverse = (point, opt) => {
+	h.assertValidProjected(point)
+	opt = h.options(opt)
+
+	const result = {
+		lon: h.deg((2 * point.x - 1) * Math.PI),
+		lat: h.deg(Math.asin(1 - 2 * Math.PI * point.y))
+	}
+	return h.addMeridian(result, opt.meridian * -1)
+}
+
+module.exports = {
+	project: lambertProject,
+	inverse: lambertInverse
+}

--- a/mercator.js
+++ b/mercator.js
@@ -2,23 +2,29 @@
 
 const h = require('./helpers')
 
-const mercator = (point, opt) => {
-	point = h.validatePoint(point)
+const mercatorProject = (point, opt) => {
+	h.assertValidUnprojected(point)
 	opt = h.options(opt)
-	if(point.wgs){
-		point = h.addMeridian(point, opt.meridian)
-		return {
-			x: h.rad(point.lon)/(2*Math.PI)+0.5,
-			y: (Math.atanh(h.sin(opt.latLimit))-Math.atanh(h.sin(point.lat)))/(2*Math.PI)
-		}
-	}
-	else{
-		const result = {
-			lon: h.deg((2*point.x-1)*Math.PI),
-			lat: h.deg(Math.asin(Math.tanh((Math.atanh(h.sin(opt.latLimit))-2*Math.PI*point.y))))
-		}
-		return h.addMeridian(result, opt.meridian*(-1))
+
+	point = h.addMeridian(point, opt.meridian)
+	return {
+		x: h.rad(point.lon) / (2 * Math.PI) + 0.5,
+		y: (Math.atanh(h.sin(opt.latLimit)) - Math.atanh(h.sin(point.lat))) / (2 * Math.PI)
 	}
 }
 
-module.exports = mercator
+const mercatorInverse = (point, opt) => {
+	h.assertValidProjected(point)
+	opt = h.options(opt)
+
+	const result = {
+		lon: h.deg((2 * point.x - 1) * Math.PI),
+		lat: h.deg(Math.asin(Math.tanh((Math.atanh(h.sin(opt.latLimit)) - 2 * Math.PI *point.y))))
+	}
+	return h.addMeridian(result, opt.meridian * -1)
+}
+
+module.exports = {
+	project: mercatorProject,
+	inverse: mercatorInverse
+}

--- a/mercator.js
+++ b/mercator.js
@@ -3,7 +3,7 @@
 const h = require('./helpers')
 
 const mercator = (point, opt) => {
-	point = h.check(point)
+	point = h.validatePoint(point)
 	opt = h.options(opt)
 	if(point.wgs){
 		point = h.addMeridian(point, opt.meridian)

--- a/miller.js
+++ b/miller.js
@@ -2,24 +2,30 @@
 
 const h = require('./helpers')
 
-const miller = (point, opt) => {
-	point = h.validatePoint(point)
+const millerProject = (point, opt) => {
+	h.assertValidUnprojected(point)
 	opt = h.options(opt)
-	if(point.wgs){
-		point = h.addMeridian(point, opt.meridian)
-		return {
-			x: h.rad(point.lon)/(2*Math.PI)+0.5,
-			y: (Math.atanh(h.sin(opt.latLimit*4/5))-Math.atanh(h.sin(point.lat*4/5)))/(2*Math.PI)*(5/4)
-		}
-	}
-	// mercator(4/5)*5/4?
-	else{
-		const result = {
-			lon: h.deg((2*point.x-1)*Math.PI),
-			lat: h.deg((5/4)*Math.asin(Math.tanh((Math.atanh(h.sin(opt.latLimit*(4/5)))-8*Math.PI*point.y/5))))
-		}
-		return h.addMeridian(result, opt.meridian*(-1))
+
+	point = h.addMeridian(point, opt.meridian)
+	return {
+		x: h.rad(point.lon) / (2 * Math.PI) + 0.5,
+		y: (Math.atanh(h.sin(opt.latLimit * 4 / 5)) - Math.atanh(h.sin(point.lat * 4 / 5))) / (2 * Math.PI) * (5 / 4)
 	}
 }
 
-module.exports = miller
+const millerInverse = (point, opt) => {
+	h.assertValidProjected(point)
+	opt = h.options(opt)
+
+	// mercator(4/5)*5/4?
+	const result = {
+		lon: h.deg((2 * point.x - 1) * Math.PI),
+		lat: h.deg((5/4) * Math.asin(Math.tanh((Math.atanh(h.sin(opt.latLimit * 4 / 5)) - 8 * Math.PI * point.y / 5))))
+	}
+	return h.addMeridian(result, opt.meridian * -1)
+}
+
+module.exports = {
+	project: millerProject,
+	inverse: millerInverse
+}

--- a/miller.js
+++ b/miller.js
@@ -3,7 +3,7 @@
 const h = require('./helpers')
 
 const miller = (point, opt) => {
-	point = h.check(point)
+	point = h.validatePoint(point)
 	opt = h.options(opt)
 	if(point.wgs){
 		point = h.addMeridian(point, opt.meridian)

--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
 	"repository": "juliuste/projections",
 	"bugs": "https://github.com/juliuste/projections/issues",
 	"main": "./index.js",
-	"files": ["*.js", "!test.js"],
-	"dependencies": {
-	},
+	"files": [
+		"*.js",
+		"!test.js"
+	],
 	"devDependencies": {
 		"tape": "^4.6"
 	},
@@ -35,8 +36,8 @@
 		"test": "node test.js",
 		"prepublish": "npm test"
 	},
-	"engine" : {
-		"node" : ">=4"
+	"engine": {
+		"node": ">=4"
 	},
 	"license": "MIT"
 }

--- a/readme.md
+++ b/readme.md
@@ -24,17 +24,17 @@ const mercator = require('projections/mercator') // for a specific projection
 ### WGS to map coordinates
 
 ```js
-const {x, y} = mercator({lon: 13.5, lat: 52.4})
+const {x, y} = mercator.project({lon: 13.5, lat: 52.4})
 // x ≊ 0.53722
 // y ≊ 0.32686
 ```
 
-Given an object containing `lon` and `lat`, `mercator` returns an object `{x: …, y: …}` (`0 ≤ x ≤ 1`). For details on the range of `y`, see the *map height* column in the projections table.
+Given an object containing `lon` and `lat`, `mercator.project` returns an object `{x: …, y: …}` (`0 ≤ x ≤ 1`). For details on the range of `y`, see the *map height* column in the [projections table](#projections).
 
 ### Map coordinates to WGS
 
 ```js
-const {lon, lat} = mercator({x: 0.53722, y: 0.32686})
+const {lon, lat} = mercator.inverse({x: 0.53722, y: 0.32686})
 // lon ≊ 13.5
 // lat ≊ 52.4
 ```

--- a/sinusoidal.js
+++ b/sinusoidal.js
@@ -3,7 +3,7 @@
 const h = require('./helpers')
 
 const sinusoidal = (point, opt) => {
-	point = h.check(point)
+	point = h.validatePoint(point)
 	opt = h.options(opt)
 	if(point.wgs){
 		point = h.addMeridian(point, opt.meridian)

--- a/sinusoidal.js
+++ b/sinusoidal.js
@@ -2,24 +2,30 @@
 
 const h = require('./helpers')
 
-const sinusoidal = (point, opt) => {
-	point = h.validatePoint(point)
+const sinusoidalProject = (point, opt) => {
+	h.assertValidUnprojected(point)
 	opt = h.options(opt)
-	if(point.wgs){
-		point = h.addMeridian(point, opt.meridian)
-		return {
-			x: h.rad(point.lon)*h.cos(point.lat)/(2*Math.PI)+0.5,
-			y: (Math.PI/2-h.rad(point.lat))/(2*Math.PI)
-		}
-	}
-	else{
-		const lat = h.deg(Math.PI/2 - 2*Math.PI*point.y)
-		const result = {
-			lon: h.deg((2*point.x-1)*Math.PI/h.cos(lat)),
-			lat: lat
-		}
-		return h.addMeridian(result, opt.meridian*(-1))
+
+	point = h.addMeridian(point, opt.meridian)
+	return {
+		x: h.rad(point.lon) * h.cos(point.lat) / (2 * Math.PI) + 0.5,
+		y: (Math.PI / 2 - h.rad(point.lat)) / (2 * Math.PI)
 	}
 }
 
-module.exports = sinusoidal
+const sinusoidalInverse = (point, opt) => {
+	h.assertValidProjected(point)
+	opt = h.options(opt)
+
+	const lat = h.deg(Math.PI / 2 - 2 * Math.PI * point.y)
+	const result = {
+		lon: h.deg((2 * point.x - 1) * Math.PI / h.cos(lat)),
+		lat: lat
+	}
+	return h.addMeridian(result, opt.meridian * -1)
+}
+
+module.exports = {
+	project: sinusoidalProject,
+	inverse: sinusoidalInverse
+}

--- a/test.js
+++ b/test.js
@@ -20,10 +20,10 @@ const assertInverse = (test, obj, projection) => {
 }
 
 // fixtures
-const wgs = h.check({lon: 180, lat: 0})
-const wgs2 = h.check({lon: -24, lat: 60})
-const wgs3 = h.check({lon: 0, lat: 90})
-const coords = h.check({x: 0.5, y: 0})
+const wgs = h.validatePoint({lon: 180, lat: 0})
+const wgs2 = h.validatePoint({lon: -24, lat: 60})
+const wgs3 = h.validatePoint({lon: 0, lat: 90})
+const coords = h.validatePoint({x: 0.5, y: 0})
 
 
 
@@ -47,8 +47,8 @@ test('trigonometry helpers', (t) => {
 // TODO: check()
 
 test('meridian calculations', (t) => {
-	const m1 = h.check({lon: 70, lat: 30})
-	const m2 = h.check({lon: -170, lat: 20})
+	const m1 = h.validatePoint({lon: 70, lat: 30})
+	const m2 = h.validatePoint({lon: -170, lat: 20})
 	t.plan(6)
 	t.equal(h.addMeridian(m1, 60).lon, 10)
 	t.equal(h.addMeridian(m2, -30).lon, -140)

--- a/test.js
+++ b/test.js
@@ -20,10 +20,10 @@ const assertInverse = (test, obj, projection) => {
 }
 
 // fixtures
-const wgs = h.validatePoint({lon: 180, lat: 0})
-const wgs2 = h.validatePoint({lon: -24, lat: 60})
-const wgs3 = h.validatePoint({lon: 0, lat: 90})
-const coords = h.validatePoint({x: 0.5, y: 0})
+const wgs = {lon: 180, lat: 0}
+const wgs2 = {lon: -24, lat: 60}
+const wgs3 = {lon: 0, lat: 90}
+const coords = {x: 0.5, y: 0}
 
 
 
@@ -44,11 +44,12 @@ test('trigonometry helpers', (t) => {
 	t.equal(round(h.deg(Math.PI/2)), 90)
 })
 
-// TODO: check()
+// TODO: assertValidUnprojected()
+// TODO: assertValidProjected()
 
 test('meridian calculations', (t) => {
-	const m1 = h.validatePoint({lon: 70, lat: 30})
-	const m2 = h.validatePoint({lon: -170, lat: 20})
+	const m1 = {lon: 70, lat: 30}
+	const m2 = {lon: -170, lat: 20}
 	t.plan(6)
 	t.equal(h.addMeridian(m1, 60).lon, 10)
 	t.equal(h.addMeridian(m2, -30).lon, -140)

--- a/test.js
+++ b/test.js
@@ -7,16 +7,16 @@ const test = require('tape')
 // test helpers
 const round = (number) => Math.round(number*100000)/100000
 const round3 = (number) => Math.round(number*100)/100
-const roundObj = (obj) => {
-	obj = Object.assign({}, obj)
-	for(let key in obj)
-		obj[key] = round3(obj[key])
-	return obj
-}
+
+const hasProp = (o, k) => Object.prototype.hasOwnProperty.call(o, k)
 const assertInverse = (test, obj, projection) => {
 	const forth = projection(obj, {meridian: 40})
 	const back = projection(forth, {meridian: 40})
-	test.deepEqual(roundObj(obj), roundObj(back))
+
+	for (let k in obj) {
+		if (!hasProp(obj, k)) continue
+		test.equal(round3(obj[k]), round3(back[k]), 'inverse failed at ' + k)
+	}
 }
 
 // fixtures
@@ -28,12 +28,11 @@ const coords = h.check({x: 0.5, y: 0})
 
 
 test('test helpers', (t) => {
-	t.plan(5)
+	t.plan(4)
 	t.equal(round(1.222226), round(1.2222325))
 	t.equal(round(-.2), round(-.2))
 	t.equal(round3(1.226), round3(1.234))
 	t.equal(round3(-1.2), round3(-1.2))
-	t.deepEqual(roundObj({l: 1.226}), roundObj({l: 1.234}))
 })
 
 test('trigonometry helpers', (t) => {
@@ -85,83 +84,83 @@ test('requiring projections directly', (t) => {
 
 
 test('Braun projection', (t) => {
-	t.plan(3)
 	t.equal(round(p.braun(wgs).x), 1)
 	t.equal(round3(p.braun(coords).lon), 0)
 	assertInverse(t, wgs2, p.braun)
+	t.end()
 })
 
 test('central cylindrical projection', (t) => {
-	t.plan(3)
 	t.equal(round(p.centralCylindrical(wgs).x), 1)
 	t.equal(round3(p.centralCylindrical(coords).lon), 0)
 	assertInverse(t, wgs2, p.centralCylindrical)
+	t.end()
 })
 
 test('equirectangular projection', (t) => {
-	t.plan(3)
 	t.equal(round(p.equirectangular(wgs).x), 1)
 	t.equal(round3(p.equirectangular(coords).lon), 0)
 	assertInverse(t, wgs2, p.equirectangular)
+	t.end()
 })
 
 test('Gall projection', (t) => {
-	t.plan(3)
 	t.equal(round(p.gall(wgs).x), 1)
 	t.equal(round3(p.gall(coords).lon), 0)
 	assertInverse(t, wgs2, p.gall)
+	t.end()
 })
 
 test('Gall-Peters projection', (t) => {
-	t.plan(4)
 	t.equal(round(p.gallPeters(wgs).x), 1)
 	t.equal(round3(p.gallPeters(coords).lon), 0)
 	assertInverse(t, wgs2, p.gallPeters)
 	t.equal(round(p.gallPeters(wgs3).y), 0)
+	t.end()
 })
 
 test('Kavrayskiy VII projection', (t) => {
-	t.plan(4)
 	t.equal(round(p.kavrayskiy7(wgs).x), 1)
 	t.equal(round3(p.kavrayskiy7(coords).lon), 0)
 	assertInverse(t, wgs2, p.kavrayskiy7)
 	t.equal(round(p.kavrayskiy7(wgs3).y), 0)
+	t.end()
 })
 
 test('Lambert projection', (t) => {
-	t.plan(4)
 	t.equal(round(p.lambert(wgs).x), 1)
 	t.equal(round3(p.lambert(coords).lon), 0)
 	assertInverse(t, wgs2, p.lambert)
 	t.equal(round(p.lambert(wgs3).y), 0)
+	t.end()
 })
 
 test('Mercator projection', (t) => {
-	t.plan(3)
 	t.equal(round(p.mercator(wgs).x), 1)
 	t.equal(round3(p.mercator(coords).lon), 0)
 	assertInverse(t, wgs2, p.mercator)
+	t.end()
 })
 
 test('Miller projection', (t) => {
-	t.plan(3)
 	t.equal(round(p.miller(wgs).x), 1)
 	t.equal(round3(p.miller(coords).lon), 0)
 	assertInverse(t, wgs2, p.miller)
+	t.end()
 })
 
 test('sinusoidal projection', (t) => {
-	t.plan(4)
 	t.equal(round(p.sinusoidal(wgs).x), 1)
 	t.equal(round3(p.sinusoidal(coords).lon), 0)
 	assertInverse(t, wgs2, p.sinusoidal)
 	t.equal(round(p.sinusoidal(wgs3).y), 0)
+	t.end()
 })
 
 test('Wagner VI projection', (t) => {
-	t.plan(4)
 	t.equal(round(p.wagner6(wgs).x), 1)
 	t.equal(round3(p.wagner6(coords).lon), 0)
 	assertInverse(t, wgs2, p.wagner6)
 	t.equal(round(p.wagner6(wgs3).y), 0)
+	t.end()
 })

--- a/test.js
+++ b/test.js
@@ -10,8 +10,8 @@ const round3 = (number) => Math.round(number*100)/100
 
 const hasProp = (o, k) => Object.prototype.hasOwnProperty.call(o, k)
 const assertInverse = (test, obj, projection) => {
-	const forth = projection(obj, {meridian: 40})
-	const back = projection(forth, {meridian: 40})
+	const forth = projection.project(obj, {meridian: 40})
+	const back = projection.inverse(forth, {meridian: 40})
 
 	for (let k in obj) {
 		if (!hasProp(obj, k)) continue
@@ -85,83 +85,83 @@ test('requiring projections directly', (t) => {
 
 
 test('Braun projection', (t) => {
-	t.equal(round(p.braun(wgs).x), 1)
-	t.equal(round3(p.braun(coords).lon), 0)
+	t.equal(round(p.braun.project(wgs).x), 1)
+	t.equal(round3(p.braun.inverse(coords).lon), 0)
 	assertInverse(t, wgs2, p.braun)
 	t.end()
 })
 
 test('central cylindrical projection', (t) => {
-	t.equal(round(p.centralCylindrical(wgs).x), 1)
-	t.equal(round3(p.centralCylindrical(coords).lon), 0)
+	t.equal(round(p.centralCylindrical.project(wgs).x), 1)
+	t.equal(round3(p.centralCylindrical.inverse(coords).lon), 0)
 	assertInverse(t, wgs2, p.centralCylindrical)
 	t.end()
 })
 
 test('equirectangular projection', (t) => {
-	t.equal(round(p.equirectangular(wgs).x), 1)
-	t.equal(round3(p.equirectangular(coords).lon), 0)
+	t.equal(round(p.equirectangular.project(wgs).x), 1)
+	t.equal(round3(p.equirectangular.inverse(coords).lon), 0)
 	assertInverse(t, wgs2, p.equirectangular)
 	t.end()
 })
 
 test('Gall projection', (t) => {
-	t.equal(round(p.gall(wgs).x), 1)
-	t.equal(round3(p.gall(coords).lon), 0)
+	t.equal(round(p.gall.project(wgs).x), 1)
+	t.equal(round3(p.gall.inverse(coords).lon), 0)
 	assertInverse(t, wgs2, p.gall)
 	t.end()
 })
 
 test('Gall-Peters projection', (t) => {
-	t.equal(round(p.gallPeters(wgs).x), 1)
-	t.equal(round3(p.gallPeters(coords).lon), 0)
+	t.equal(round(p.gallPeters.project(wgs).x), 1)
+	t.equal(round3(p.gallPeters.inverse(coords).lon), 0)
 	assertInverse(t, wgs2, p.gallPeters)
-	t.equal(round(p.gallPeters(wgs3).y), 0)
+	t.equal(round(p.gallPeters.project(wgs3).y), 0)
 	t.end()
 })
 
 test('Kavrayskiy VII projection', (t) => {
-	t.equal(round(p.kavrayskiy7(wgs).x), 1)
-	t.equal(round3(p.kavrayskiy7(coords).lon), 0)
+	t.equal(round(p.kavrayskiy7.project(wgs).x), 1)
+	t.equal(round3(p.kavrayskiy7.inverse(coords).lon), 0)
 	assertInverse(t, wgs2, p.kavrayskiy7)
-	t.equal(round(p.kavrayskiy7(wgs3).y), 0)
+	t.equal(round(p.kavrayskiy7.project(wgs3).y), 0)
 	t.end()
 })
 
 test('Lambert projection', (t) => {
-	t.equal(round(p.lambert(wgs).x), 1)
-	t.equal(round3(p.lambert(coords).lon), 0)
+	t.equal(round(p.lambert.project(wgs).x), 1)
+	t.equal(round3(p.lambert.inverse(coords).lon), 0)
 	assertInverse(t, wgs2, p.lambert)
-	t.equal(round(p.lambert(wgs3).y), 0)
+	t.equal(round(p.lambert.project(wgs3).y), 0)
 	t.end()
 })
 
 test('Mercator projection', (t) => {
-	t.equal(round(p.mercator(wgs).x), 1)
-	t.equal(round3(p.mercator(coords).lon), 0)
+	t.equal(round(p.mercator.project(wgs).x), 1)
+	t.equal(round3(p.mercator.inverse(coords).lon), 0)
 	assertInverse(t, wgs2, p.mercator)
 	t.end()
 })
 
 test('Miller projection', (t) => {
-	t.equal(round(p.miller(wgs).x), 1)
-	t.equal(round3(p.miller(coords).lon), 0)
+	t.equal(round(p.miller.project(wgs).x), 1)
+	t.equal(round3(p.miller.inverse(coords).lon), 0)
 	assertInverse(t, wgs2, p.miller)
 	t.end()
 })
 
 test('sinusoidal projection', (t) => {
-	t.equal(round(p.sinusoidal(wgs).x), 1)
-	t.equal(round3(p.sinusoidal(coords).lon), 0)
+	t.equal(round(p.sinusoidal.project(wgs).x), 1)
+	t.equal(round3(p.sinusoidal.inverse(coords).lon), 0)
 	assertInverse(t, wgs2, p.sinusoidal)
-	t.equal(round(p.sinusoidal(wgs3).y), 0)
+	t.equal(round(p.sinusoidal.project(wgs3).y), 0)
 	t.end()
 })
 
 test('Wagner VI projection', (t) => {
-	t.equal(round(p.wagner6(wgs).x), 1)
-	t.equal(round3(p.wagner6(coords).lon), 0)
+	t.equal(round(p.wagner6.project(wgs).x), 1)
+	t.equal(round3(p.wagner6.inverse(coords).lon), 0)
 	assertInverse(t, wgs2, p.wagner6)
-	t.equal(round(p.wagner6(wgs3).y), 0)
+	t.equal(round(p.wagner6.project(wgs3).y), 0)
 	t.end()
 })

--- a/wagner-6.js
+++ b/wagner-6.js
@@ -4,7 +4,7 @@ const h = require('./helpers')
 const kavrayskiy7 = require('./kavrayskiy-7')
 
 const wagner6 = (point, opt) => {
-	point = h.check(point)
+	point = h.validatePoint(point)
 	opt = h.options(opt)
 	if(point.wgs){
 		point = kavrayskiy7(point, opt)

--- a/wagner-6.js
+++ b/wagner-6.js
@@ -3,23 +3,29 @@
 const h = require('./helpers')
 const kavrayskiy7 = require('./kavrayskiy-7')
 
-const wagner6 = (point, opt) => {
-	point = h.validatePoint(point)
+const wagner6Project = (point, opt) => {
+	h.assertValidUnprojected(point)
 	opt = h.options(opt)
-	if(point.wgs){
-		point = kavrayskiy7(point, opt)
-		return {
-			x: point.x,
-			y: point.y*Math.sqrt(3)/2
-		}
-	}
-	else{
-		point = {
-			x: point.x,
-			y: point.y*2/Math.sqrt(3)
-		}
-		return kavrayskiy7(point, opt)
+
+	point = kavrayskiy7.project(point, opt)
+	return {
+		x: point.x,
+		y: point.y * Math.sqrt(3) / 2
 	}
 }
 
-module.exports = wagner6
+const wagner6Inverse = (point, opt) => {
+	h.assertValidProjected(point)
+	opt = h.options(opt)
+
+	point = {
+		x: point.x,
+		y: point.y * 2 / Math.sqrt(3)
+	}
+	return kavrayskiy7.inverse(point, opt)
+}
+
+module.exports = {
+	project: wagner6Project,
+	inverse: wagner6Inverse
+}


### PR DESCRIPTION
This PR changes the interface of each projection (#2). It is therefore a breaking change.

Now, an individual projection looks like this:

```js
const mercator = require('projections/mercator')

mercator.project({lon: …, lat: …}) // {x: …, y: …}
mercator.inverse({x: …, y: …}) // {lon: …, lat: …}
```

In addition, the validation helper functions will now throw more helpful error messages.